### PR TITLE
Fix to allow building of PDF version

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -112,7 +112,7 @@ htmlhelp_basename = 'AlloyDocumentationdoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
-
+latex_engine = "xelatex" # solves problem of unicode characters
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ The docs currently run on Sphinx. You can install Sphinx with [these instruction
 python -m pip install sphinx-rtd-theme
 ```
 
-Docs can be built with ``make html``.
+Docs can be built with ``make html``. Single file PDF version can be built with ``make latexpdf`` (requires LaTeX installed).
 
 ## Development
 


### PR DESCRIPTION
Defined latex_engine in conf.py which solves unicode characters stopping the building of PDF file with make latexpdf.

Not sure how much it will be useful to others but I wanted to put the docs into my book reader and this small change allowed to build PDF file.

Many thanks!
Adam.